### PR TITLE
Zip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # sample data folder
 submissions
+sample
 
 # ignore .csv/xlsl...
 *.csv

--- a/main.py
+++ b/main.py
@@ -87,8 +87,10 @@ if "java" in argSet:
 if "zip" in argSet:
     for zipFileName in zipFilesToUnzip:
         try:
+            zipFileNameSplit = zipFileName.split("/")
             zipFile = zf.ZipFile(zipFileName, "r")
-            targetDir = "./" + zipFileName.split("/")[1]
+            # ./lastfirst/zipfilename/
+            targetDir = "./" + zipFileNameSplit[1] + "/" + zipFileNameSplit[2].split(".")[0]
             zipFile.extractall(targetDir)
             zipFile.close()
         except Exception, e: 

--- a/main.py
+++ b/main.py
@@ -44,26 +44,30 @@ for folderName, subFolders, fileNames in os.walk("./"):
         # Piece together file names
         fileSplit = filename.split("_")
 
+        # Preserve file extension.  
+        fileExtension = filename.split(".")[-1]
+
         # name starts at index 3 if not late, if late then index 4
-        startIndex = 3 if not "_late_" in filename else 4
+        startIndex = 3
+        if "_late_" in filename:
+            startIndex = 4
+            outputMessages.append("[late] " + filename + " was submitted late.")
         className = fileSplit[startIndex] 
         # If there are additional underscores, append them to the class name.
         for piece in fileSplit[(startIndex + 1):]:
             className += "_" + piece
 
         # Get rid of any additional submission marks, like -1.java or -2.java
-        className = re.sub("-[0-9]*.java", ".java", className)
+        className = re.sub("-[0-9]*." + fileExtension, "." + fileExtension, className)
 
-        # Rename the files to their "real" names that should compile...
-        # print("Renaming " + folderName + "/" + filename + " to " +folderName + "/" + className)
-        oldLocation = folderName + "/" + filename
-        newLocation = folderName + "/" + className
-        shutil.move(oldLocation, newLocation)
+        # Rename the files to their original names.
+        dirName = folderName + "/"
+        shutil.move(dirName + filename, dirName + className)
 
-        if newLocation.endswith(".java"):
-            javaFilesToCompile.add(newLocation)
-        elif newLocation.endswith(".zip"):
-            zipFilesToUnzip.add(newLocation)
+        if className.endswith(".java"):
+            javaFilesToCompile.add(className)
+        elif className.endswith(".zip"):
+            zipFilesToUnzip.add(className)
 
 # After the walk, do some operations:
 # java: attempt to compile java files.
@@ -76,7 +80,7 @@ if "java" in argSet:
         exitCode = subprocess.call(["javac", filename],
                                 cwd=workingDir)
         if exitCode != 0:
-            outputMessages.append("[javac] Failed to compile: " + sourceFile)
+            outputMessages.append("[javac] " + sourceFile + "failed to compile.")
 
 # zip: unzip submitted zip files.
 if "zip" in argSet:

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import sys
 import shutil
 import re
 import subprocess
+import zipfile as zf
 
 # Evaluate parameters before starting
 argSet = set()
@@ -69,11 +70,11 @@ for folderName, subFolders, fileNames in os.walk("./"):
         elif className.endswith(".zip"):
             zipFilesToUnzip.add(className)
 
-# After the walk, do some operations:
+# After the walk, do some operations.
+# The file names in each set look like: ./lastfirst/Exercise12_21.java
 # java: attempt to compile java files.
 if "java" in argSet:
     for sourceFile in javaFilesToCompile:
-        # Source file looks like: ./lastfirst/Exercise12_21.java
         workingDir =  "./" + sourceFile.split("/")[1]
         filename = sourceFile.split("/")[2]
 
@@ -84,8 +85,14 @@ if "java" in argSet:
 
 # zip: unzip submitted zip files.
 if "zip" in argSet:
-    for zipFile in zipFilesToUnzip:
-        print(zipFile)
+    for zipFileName in zipFilesToUnzip:
+        try:
+            zipFile = zf.ZipFile(zipFileName, "r")
+            targetDir = "./" + zipFileName.split("/")[1]
+            zipFile.extractall(targetDir)
+            zipFile.close()
+        except: 
+            outputMessages.append("[zip] " + zipFileName + " failed to extract.")
 
 # Sort and display output messages.
 outputMessages.sort()

--- a/main.py
+++ b/main.py
@@ -68,7 +68,7 @@ for folderName, subFolders, fileNames in os.walk("./"):
         if className.endswith(".java"):
             javaFilesToCompile.add(className)
         elif className.endswith(".zip"):
-            zipFilesToUnzip.add(className)
+            zipFilesToUnzip.add(dirName + className)
 
 # After the walk, do some operations.
 # The file names in each set look like: ./lastfirst/Exercise12_21.java
@@ -91,8 +91,8 @@ if "zip" in argSet:
             targetDir = "./" + zipFileName.split("/")[1]
             zipFile.extractall(targetDir)
             zipFile.close()
-        except: 
-            outputMessages.append("[zip] " + zipFileName + " failed to extract.")
+        except Exception, e: 
+            outputMessages.append("[zip] " + zipFileName + " failed to extract: " + e)
 
 # Sort and display output messages.
 outputMessages.sort()

--- a/main.py
+++ b/main.py
@@ -16,6 +16,10 @@ students = set()
 # Messages to output at the end of everything:
 outputMessages = []
 
+# List of files to compile, unzip, and do other operations to
+javaFilesToCompile = set()
+zipFilesToUnzip = set()
+
 # Add students to set and make folders for each of them.
 for file in os.listdir("./"):
     student = file.split("_")[0]
@@ -30,9 +34,6 @@ for file in os.listdir("./"):
     # Move student file to their directory that should exist by now.
     if os.path.isfile(file):
         shutil.move(file, studentdir + "/" + file)
-
-# Keep a list of everything to compile after this walk.
-filesToCompile = set()
 
 # Now we step through the whole file tree, renaming files appropriately.
 for folderName, subFolders, fileNames in os.walk("./"):
@@ -60,12 +61,14 @@ for folderName, subFolders, fileNames in os.walk("./"):
         shutil.move(oldLocation, newLocation)
 
         if newLocation.endswith(".java"):
-            filesToCompile.add(newLocation)
+            javaFilesToCompile.add(newLocation)
+        elif newLocation.endswith(".zip"):
+            zipFilesToUnzip.add(newLocation)
 
 # After the walk, do some operations:
 # java: attempt to compile java files.
 if "java" in argSet:
-    for sourceFile in filesToCompile:
+    for sourceFile in javaFilesToCompile:
         # Source file looks like: ./lastfirst/Exercise12_21.java
         workingDir =  "./" + sourceFile.split("/")[1]
         filename = sourceFile.split("/")[2]
@@ -74,6 +77,11 @@ if "java" in argSet:
                                 cwd=workingDir)
         if exitCode != 0:
             outputMessages.append("[javac] Failed to compile: " + sourceFile)
+
+# zip: unzip submitted zip files.
+if "zip" in argSet:
+    for zipFile in zipFilesToUnzip:
+        print(zipFile)
 
 # Sort and display output messages.
 outputMessages.sort()


### PR DESCRIPTION
1. Add support for zip files: when the `zip` argument is passed, its contents are extracted to a sub-folder of the student's folder.
2. Refactor all argument passing: 
a. Now, the script can be run without any arguments, and it will work for all file types.
b. For additional file processing, such as unzipping or java compilation, the arguments `zip` and `java` can be passed.